### PR TITLE
Handle missing googlesearch dependency

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,11 @@
+# Recipe Diet Project
+
+## Dependencies
+
+Install required packages before running the update scripts:
+
+```bash
+pip install -r requirements.txt
+```
+
+This includes the `googlesearch-python` package used by `update_cooking_links.py` to retrieve recipe links.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+googlesearch-python

--- a/update_cooking_links.py
+++ b/update_cooking_links.py
@@ -1,6 +1,15 @@
 import json
 import time
 import os
+import sys
+import importlib.util
+
+if importlib.util.find_spec("googlesearch") is None:
+    print(
+        "The 'googlesearch' package is required. Install it with 'pip install googlesearch-python'."
+    )
+    sys.exit(1)
+
 from googlesearch import search
 
 def update_cooking_links():


### PR DESCRIPTION
## Summary
- add a requirements.txt listing the googlesearch dependency
- guard update_cooking_links.py against a missing googlesearch installation and provide install guidance
- document installing dependencies, including googlesearch-python, in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfe6f55a3c83219ea686e6c80cd717